### PR TITLE
onWillSaveUntil => onWillSaveTextDocument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
   }, null, subscriptions)
 
-  let disposable = workspace.onWillSaveUntil(async ev => {
+  let disposable = workspace.onWillSaveTextDocument(async ev => {
     if (!autoFixOnSave) return
     let thenable = async () => {
       let { document } = ev
@@ -46,7 +46,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       if (action && action.edit) await workspace.applyEdit(action.edit)
     }
     ev.waitUntil(thenable())
-  }, null, 'tslint')
+  })
   subscriptions.push(disposable)
 }
 


### PR DESCRIPTION
I recently started seeing this error in the CocLog:
```
2020-12-23T13:45:24.563 ERROR (pid:1540519) [extensions] - Error on active extension coc-tslint-plugin: TypeError: coc_nvim_1.workspace.onWillSaveUntil is not a function
    at Object.<anonymous> (/home/redacted/.config/coc/extensions/node_modules/coc-tslint-plugin/lib/index.js:126:47)
```
I tracked down this issue in the coc release:
https://github.com/neoclide/coc.nvim/issues/2704

after cloning this lib, applying this fix, and copying over to my coc plugins, the error goes away.

I'm not 100% certain on this fix, but figured it's close at least. 